### PR TITLE
Changed "disabled" to "enabled" in paragraph 1, sentence 2 to accurat…

### DIFF
--- a/SOPs/Git_Standard_Operating_Procedures.md
+++ b/SOPs/Git_Standard_Operating_Procedures.md
@@ -1,7 +1,7 @@
 # Git Standard Operating Procedures.
 
 ## Overview
-We will be using the rebase and merge strategy for keeping our history clean. As a safety net, only 'Rebase and merge' has been disabled for all our repositories. If you have not yet worked using this strategy, check out this [tutorial](https://www.atlassian.com/git/tutorials/merging-vs-rebasing) online.
+We will be using the rebase and merge strategy for keeping our history clean. As a safety net, only 'Rebase and merge' has been enabled for all our repositories. If you have not yet worked using this strategy, check out this [tutorial](https://www.atlassian.com/git/tutorials/merging-vs-rebasing) online.
 
 We highly recommend using a tool such as SourceTree to help you visualize what is going on with the history and your current place in it.
 


### PR DESCRIPTION
# Issue
Issue #18 
Typo in the first paragraph, second sentence stated that "Rebase and Merge" was disabled instead of enabled.

# Fix State
Fixed sentence to say "Rebase and Merge" is "enabled" instead of "disabled"